### PR TITLE
settings: Add `venvDir` setting

### DIFF
--- a/LSP-ty.sublime-settings
+++ b/LSP-ty.sublime-settings
@@ -13,6 +13,9 @@
     },
     // @see https://docs.astral.sh/ty/reference/editor-settings/
     "settings": {
+        // Path to a virtual environment directory. Can be absolute or relative to the workspace folder.
+        // When set, the Python interpreter from this venv is passed to the ty server.
+        "ty.venvDir": "",
         // Whether to disable the language services that ty provides like code completion, hover, go to definition, etc.
         // This is useful if you want to use ty exclusively for type checking in combination with another language server for features like code completion, hover, go to definition, etc.
         "ty.disableLanguageServices": false,

--- a/plugin/client.py
+++ b/plugin/client.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from typing import Any
 
 import sublime
-from LSP.plugin import AbstractPlugin, ClientConfig, DottedDict
+from LSP.plugin import AbstractPlugin, ClientConfig, DottedDict, WorkspaceFolder
 from typing_extensions import override
 
 from .constants import PACKAGE_NAME
@@ -53,6 +53,20 @@ class LspTyPlugin(AbstractPlugin):
             and not view.settings().get("repl")
         )
 
+    @override
+    @classmethod
+    def on_pre_start(
+        cls,
+        window: sublime.Window,
+        initiating_view: sublime.View,
+        workspace_folders: list[WorkspaceFolder],
+        configuration: ClientConfig,
+    ) -> str | None:
+        venv_dir = cls._find_venv_dir(workspace_folders, configuration)
+        if venv_dir:
+            configuration.env["VIRTUAL_ENV"] = str(venv_dir)
+        return None
+
     # ----- #
     # hooks #
     # ----- #
@@ -61,46 +75,31 @@ class LspTyPlugin(AbstractPlugin):
     def on_settings_changed(self, settings: DottedDict) -> None:
         super().on_settings_changed(settings)
 
+        # Remove our custom setting so it doesn't get sent to the ty server
+        settings.remove("ty.venvDir")
+
         self.update_status_bar_text()
-
-    @override
-    def on_workspace_configuration(self, params: Any, configuration: Any) -> Any:
-        if not (session := self.weaksession()):
-            return configuration
-        if not isinstance(configuration, dict):
-            return configuration
-
-        # Don't override if the user already set an interpreter explicitly
-        if configuration.get("interpreter"):
-            return configuration
-
-        venv_dir = self._find_venv_dir(session)
-        if venv_dir:
-            python = venv_dir / "Scripts" / "python.exe" if sys.platform == "win32" else venv_dir / "bin" / "python"
-            if python.is_file():
-                configuration["interpreter"] = [str(python)]
-
-        return configuration
 
     # -------------- #
     # custom methods #
     # -------------- #
 
-    def _find_venv_dir(self, session: Any) -> Path | None:
+    @classmethod
+    def _find_venv_dir(
+        cls, workspace_folders: list[WorkspaceFolder], configuration: ClientConfig
+    ) -> Path | None:
         """Find a virtual environment directory, checking the ty.venvDir setting first, then auto-detecting."""
-        workspace_folders = session.get_workspace_folders()
         if not workspace_folders:
             return None
-        # Use the first workspace folder as the project root
         project_dir = Path(workspace_folders[0].path)
 
         # 1. Check explicit setting
-        venv_dir_setting = session.config.settings.get("ty.venvDir") or ""
+        venv_dir_setting = configuration.settings.get("ty.venvDir") or ""
         if venv_dir_setting:
             path = Path(venv_dir_setting)
             if not path.is_absolute():
                 path = project_dir / path
-            if self._is_venv(path):
+            if cls._is_venv(path):
                 return path
             return None
 

--- a/plugin/client.py
+++ b/plugin/client.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import sys
+from pathlib import Path
 from typing import Any
 
 import sublime
@@ -61,9 +63,51 @@ class LspTyPlugin(AbstractPlugin):
 
         self.update_status_bar_text()
 
+    @override
+    def on_workspace_configuration(self, params: Any, configuration: Any) -> Any:
+        if not (session := self.weaksession()):
+            return configuration
+        if not isinstance(configuration, dict):
+            return configuration
+
+        # Don't override if the user already set an interpreter explicitly
+        if configuration.get("interpreter"):
+            return configuration
+
+        venv_dir = self._find_venv_dir(session)
+        if venv_dir:
+            python = venv_dir / "Scripts" / "python.exe" if sys.platform == "win32" else venv_dir / "bin" / "python"
+            if python.is_file():
+                configuration["interpreter"] = [str(python)]
+
+        return configuration
+
     # -------------- #
     # custom methods #
     # -------------- #
+
+    def _find_venv_dir(self, session: Any) -> Path | None:
+        """Find a virtual environment directory, checking the ty.venvDir setting first, then auto-detecting."""
+        workspace_folders = session.get_workspace_folders()
+        if not workspace_folders:
+            return None
+        # Use the first workspace folder as the project root
+        project_dir = Path(workspace_folders[0].path)
+
+        # 1. Check explicit setting
+        venv_dir_setting = session.config.settings.get("ty.venvDir") or ""
+        if venv_dir_setting:
+            path = Path(venv_dir_setting)
+            if not path.is_absolute():
+                path = project_dir / path
+            if self._is_venv(path):
+                return path
+            return None
+
+    @staticmethod
+    def _is_venv(path: Path) -> bool:
+        """Check if a directory looks like a Python virtual environment."""
+        return path.is_dir() and (path / "pyvenv.cfg").is_file()
 
     def update_status_bar_text(self, extra_variables: dict[str, Any] | None = None) -> None:
         if not (session := self.weaksession()):


### PR DESCRIPTION
_Unclear if this is helpful to anyone but me._

This setting allows specifying where the virtual environment (venv) can be found.

The issue that this solves for me is that I use the following project structure:

```
<project_root>/example.sublime-project
<project_root>/backend/.venv <-- Python virtual env that I care about
<project_root>/frontend/
<all the rest of the files...>
```

Using this new `venvDir` setting, I can set `venvDir: "backend/.venv` in `example.sublime-project` and now `LSP-ty` will detect my Python dependencies correctly when I'm opening files in this project.