### PR TITLE
refactor: migrate to LspPlugin

### DIFF
--- a/LSP-ty.sublime-settings
+++ b/LSP-ty.sublime-settings
@@ -37,6 +37,11 @@
         // See https://jinja.palletsprojects.com/templates/
         "statusText": "{% if server_version %}v{{ server_version }}{% endif %}",
     },
+    // The path to the server binary used to start the language server.
+    // Use `auto` for the package to manage (install/update) the server automatically.
+    // NOTE: Change this instead of directly updating `command` - the `${server_path}` variable is dynamically resolved based on this setting.
+    // WARNING: Override at your own risk - using a custom binary can cause compatibility issues with server settings.
+    "server_path": "auto",
     "command": [
         "$server_path",
         "server"

--- a/plugin/__init__.py
+++ b/plugin/__init__.py
@@ -1,10 +1,6 @@
 from __future__ import annotations
 
-from LSP.plugin import register_plugin, unregister_plugin
-
 from .client import LspTyPlugin
-from .constants import SERVER_VERSION
-from .version_manager import version_manager
 
 __all__ = (
     # ST: core
@@ -17,12 +13,9 @@ __all__ = (
 
 def plugin_loaded() -> None:
     """Executed when this plugin is loaded."""
-    register_plugin(LspTyPlugin)
-
-    version_manager.client_cls = LspTyPlugin
-    version_manager.server_version = SERVER_VERSION
+    LspTyPlugin.register()
 
 
 def plugin_unloaded() -> None:
     """Executed when this plugin is unloaded."""
-    unregister_plugin(LspTyPlugin)
+    LspTyPlugin.unregister()

--- a/plugin/client.py
+++ b/plugin/client.py
@@ -18,7 +18,7 @@ class LspTyPlugin(LspPlugin):
             version_manager = VersionManager(cls.plugin_storage_path, SERVER_VERSION)
             version_manager.install_server()
             server_path = str(version_manager.server_path)
-            context.configuration.root_settings['_server_version'] = version_manager.server_version
+            context.configuration.root_settings["_server_version"] = version_manager.server_version
 
         context.variables.update({
             "server_path": server_path,
@@ -42,7 +42,7 @@ class LspTyPlugin(LspPlugin):
             return
 
         variables: dict[str, Any] = {
-            "server_version": session.config.root_settings.get('_server_version'),
+            "server_version": session.config.root_settings.get("_server_version"),
         }
 
         if extra_variables:

--- a/plugin/client.py
+++ b/plugin/client.py
@@ -11,15 +11,14 @@ from .version_manager import VersionManager
 
 
 class LspTyPlugin(LspPlugin):
-    version_manager: VersionManager | None = None
-
     @classmethod
     def on_pre_start_async(cls, context: OnPreStartContext) -> None:
         server_path = context.configuration.root_settings.get("server_path")
         if not server_path or server_path == "auto":
-            cls.version_manager = VersionManager(cls.plugin_storage_path, SERVER_VERSION)
-            cls.version_manager.install_server()
-            server_path = str(cls.version_manager.server_path)
+            version_manager = VersionManager(cls.plugin_storage_path, SERVER_VERSION)
+            version_manager.install_server()
+            server_path = str(version_manager.server_path)
+            context.configuration.root_settings['_server_version'] = version_manager.server_version
 
         context.variables.update({
             "server_path": server_path,
@@ -43,7 +42,7 @@ class LspTyPlugin(LspPlugin):
             return
 
         variables: dict[str, Any] = {
-            "server_version": self.version_manager.server_version if self.version_manager else None,
+            "server_version": session.config.root_settings.get('_server_version'),
         }
 
         if extra_variables:

--- a/plugin/client.py
+++ b/plugin/client.py
@@ -2,64 +2,37 @@ from __future__ import annotations
 
 from typing import Any
 
-import sublime
-from LSP.plugin import AbstractPlugin, ClientConfig, DottedDict
-from typing_extensions import override
+from LSP.plugin import ClientNotification, LspPlugin, OnPreStartContext
 
-from .constants import PACKAGE_NAME
+from .constants import SERVER_VERSION
 from .log import log_warning
 from .template import load_string_template
-from .version_manager import version_manager
+from .version_manager import VersionManager
 
 
-class LspTyPlugin(AbstractPlugin):
-    @override
+class LspTyPlugin(LspPlugin):
+    version_manager: VersionManager | None = None
+
     @classmethod
-    def name(cls) -> str:
-        return PACKAGE_NAME
+    def on_pre_start_async(cls, context: OnPreStartContext) -> None:
+        server_path = context.configuration.root_settings.get("server_path")
+        if not server_path or server_path == "auto":
+            cls.version_manager = VersionManager(cls.plugin_storage_path, SERVER_VERSION)
+            cls.version_manager.install_server()
+            server_path = str(cls.version_manager.server_path)
 
-    @override
-    @classmethod
-    def configuration(cls) -> tuple[sublime.Settings, str]:
-        basename = f"{cls.name()}.sublime-settings"
-        filepath = f"Packages/{cls.name()}/{basename}"
-        return sublime.load_settings(basename), filepath
-
-    @override
-    @classmethod
-    def additional_variables(cls) -> dict[str, str] | None:
-        return {
-            "server_path": str(version_manager.server_path),
-        }
-
-    @override
-    @classmethod
-    def needs_update_or_installation(cls) -> bool:
-        return not version_manager.is_installed
-
-    @override
-    @classmethod
-    def install_or_update(cls) -> None:
-        version_manager.install_server()
-
-    @override
-    @classmethod
-    def is_applicable(cls, view: sublime.View, config: ClientConfig) -> bool:
-        return bool(
-            super().is_applicable(view, config)
-            # REPL views (https://github.com/sublimelsp/LSP-pyright/issues/343)
-            and not view.settings().get("repl")
-        )
+        context.variables.update({
+            "server_path": server_path,
+        })
 
     # ----- #
     # hooks #
     # ----- #
 
-    @override
-    def on_settings_changed(self, settings: DottedDict) -> None:
-        super().on_settings_changed(settings)
-
-        self.update_status_bar_text()
+    def on_pre_send_notification_async(self, notification: ClientNotification) -> None:
+        if notification["method"] == "workspace/didChangeConfiguration":
+            self.update_status_bar_text()
+            return
 
     # -------------- #
     # custom methods #
@@ -70,7 +43,7 @@ class LspTyPlugin(AbstractPlugin):
             return
 
         variables: dict[str, Any] = {
-            "server_version": version_manager.server_version,
+            "server_version": self.version_manager.server_version if self.version_manager else None,
         }
 
         if extra_variables:

--- a/plugin/version_manager.py
+++ b/plugin/version_manager.py
@@ -1,11 +1,9 @@
 from __future__ import annotations
 
 import io
-import pathlib
+from pathlib import Path
 
-from LSP.plugin import AbstractPlugin
-
-from .constants import PACKAGE_NAME, PLATFORM_ARCH
+from .constants import PLATFORM_ARCH
 from .log import log_info
 from .utils import decompress_buffer, rmtree_ex, simple_urlopen
 
@@ -43,50 +41,37 @@ class VersionManager:
     }
     THIS_TARBALL_NAME, THIS_TARBALL_BIN_PATH = PLATFORM_TARBALLS[PLATFORM_ARCH]
 
-    def __init__(self) -> None:
-        self.client_cls: type[AbstractPlugin] | None = None
-        self.server_version = ""
+    def __init__(self, plugin_storage_path: Path, server_version: str) -> None:
+        self.plugin_storage_path = plugin_storage_path
+        self.server_version = server_version
 
     @property
-    def server_download_url(self) -> str:
-        """The URL for downloading the server tarball."""
-        return self.DOWNLOAD_URL_TEMPLATE.format(tarball_name=self.THIS_TARBALL_NAME, version=self.server_version)
-
-    @property
-    def plugin_storage_dir(self) -> pathlib.Path:
-        """The storage directory for this plugin."""
-        assert self.client_cls, "VersionManager.client_cls must be set to a subclass of Abstract"
-        return pathlib.Path(self.client_cls.storage_path()) / PACKAGE_NAME
-
-    @property
-    def versioned_server_dir(self) -> pathlib.Path:
+    def _versioned_server_dir(self) -> Path:
         """The directory specific to the current server version."""
-        return self.plugin_storage_dir / f"v{self.server_version}"
+        return self.plugin_storage_path / f"v{self.server_version}"
 
     @property
-    def server_path(self) -> pathlib.Path:
+    def server_path(self) -> Path:
         """The path of the language server binary."""
-        return self.versioned_server_dir / self.THIS_TARBALL_BIN_PATH
-
-    @property
-    def is_installed(self) -> bool:
-        """Checks if the server executable is already installed."""
-        return self.server_path.is_file()
+        return self._versioned_server_dir / self.THIS_TARBALL_BIN_PATH
 
     def install_server(self) -> None:
         """Installs the server executable."""
-        rmtree_ex(self.plugin_storage_dir, ignore_errors=True)  # delete old versions
+        if self.server_path.is_file():
+            return
 
-        log_info(f"Downloading server tarball: {self.server_download_url}")
-        data = simple_urlopen(self.server_download_url)
+        rmtree_ex(self.plugin_storage_path, ignore_errors=True)  # delete old versions
+
+        server_download_url = self.DOWNLOAD_URL_TEMPLATE.format(
+            tarball_name=self.THIS_TARBALL_NAME, version=self.server_version
+        )
+        log_info(f"Downloading server tarball: {server_download_url}")
+        data = simple_urlopen(server_download_url)
 
         decompress_buffer(
             io.BytesIO(data),
             filename=self.THIS_TARBALL_NAME,
-            dst_dir=self.versioned_server_dir,
+            dst_dir=self._versioned_server_dir,
         )
         # make the server binary executable (required on Mac/Linux)
         self.server_path.chmod(0o755)
-
-
-version_manager = VersionManager()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,11 @@
 [project]
-name = "LSP-ty"
+name = "lsp-ty"
 version = "0.0.0"
 description = "LSP helper for ty - an extremely fast Python type checker, written in Rust."
 readme = "README.md"
 requires-python = ">=3.8"
 dependencies = [
-  "Jinja2==3.*",
+  "jinja2==3.*",
   "typing-extensions>=4.12",
 ]
 
@@ -43,6 +43,7 @@ exclude = [
 ignore = ['**/.venv', '**/libs']
 stubPath = 'typings'
 pythonVersion = '3.8'
+typeCheckingMode = 'standard'
 
 [tool.ruff]
 preview = true

--- a/sublime-package.json
+++ b/sublime-package.json
@@ -10,6 +10,11 @@
           "definitions": {
             "PluginConfig": {
               "properties": {
+                "server_path": {
+                  "type": "string",
+                  "default": "auto",
+                  "markdownDescription": "The path to the server binary to use for starting the language server. Use `auto` for the package to manage (install/update) server automatically.\n\n> [!NOTE]\n> Change this instead of directly updating `command` - the `${server_path}` variable is dynamically resolved based on this setting.\n\n> [!WARNING]\n> Using custom binary could result in package settings not matching what server supports."
+                },
                 "initialization_options": {
                   "type": "object",
                   "additionalProperties": false,


### PR DESCRIPTION
Also add support for `server_path` for overriding `ty` binary while skipping managed install.